### PR TITLE
Fix update-stats CI job silently failing since Jan 23

### DIFF
--- a/scripts/fetch-citing-papers.py
+++ b/scripts/fetch-citing-papers.py
@@ -35,8 +35,8 @@ def fetch_citing_papers():
     api_key = get_ads_api_key()
     
     if not api_key:
-        print("Info: ADS_API_KEY not set. Citing papers data will not be updated.")
-        return {"papers": [], "total_citations": 0, "last_updated": datetime.utcnow().isoformat() + "Z"}
+        print("Warning: ADS_API_KEY not set. Keeping previously fetched citing papers data.")
+        return None
     
     try:
         # ADS API endpoint for search
@@ -91,14 +91,14 @@ def fetch_citing_papers():
         }
     
     except requests.exceptions.HTTPError as e:
-        print(f"HTTP Error fetching from ADS API: {e}")
-        return {"papers": [], "total_citations": 0, "last_updated": datetime.utcnow().isoformat() + "Z"}
+        print(f"Warning: HTTP error fetching from ADS API ({e}); keeping previously fetched citing papers data.")
+        return None
     except requests.exceptions.RequestException as e:
-        print(f"Error fetching from ADS API: {e}")
-        return {"papers": [], "total_citations": 0, "last_updated": datetime.utcnow().isoformat() + "Z"}
+        print(f"Warning: error fetching from ADS API ({e}); keeping previously fetched citing papers data.")
+        return None
     except Exception as e:
-        print(f"Error processing ADS response: {e}")
-        return {"papers": [], "total_citations": 0, "last_updated": datetime.utcnow().isoformat() + "Z"}
+        print(f"Warning: error processing ADS response ({e}); keeping previously fetched citing papers data.")
+        return None
 
 def infer_domain(journal_name):
     """
@@ -122,14 +122,21 @@ def infer_domain(journal_name):
 def main():
     """Fetch papers and write to JSON file."""
     print(f"Fetching papers citing asimov ({ASIMOV_BIBCODE}) from NASA ADS...")
-    
+
     data = fetch_citing_papers()
-    
-    print(f"Found {len(data['papers'])} citing papers (total: {data['total_citations']})")
-    
-    # Write to data locations (Jekyll build + public asset)
+
     output_path = Path(__file__).parent.parent / "_data" / "citing-papers.json"
     public_path = Path(__file__).parent.parent / "assets" / "data" / "citing-papers.json"
+
+    if data is None:
+        if output_path.exists():
+            print(f"Skipping write: preserving existing data at {output_path}")
+            return
+        data = {"papers": [], "total_citations": 0, "last_updated": datetime.utcnow().isoformat() + "Z"}
+
+    print(f"Found {len(data['papers'])} citing papers (total: {data['total_citations']})")
+
+    # Write to data locations (Jekyll build + public asset)
     public_path.parent.mkdir(parents=True, exist_ok=True)
     for path in (output_path, public_path):
         with open(path, "w") as f:

--- a/scripts/fetch-zenodo-releases.py
+++ b/scripts/fetch-zenodo-releases.py
@@ -57,21 +57,17 @@ def main():
     print(f"Fetching asimov releases from Zenodo (concept: {ZENODO_CONCEPT_ID})...")
     
     data = fetch_zenodo_releases()
-    
-        # Write to data locations (Jekyll build + public asset)
-        output_path = Path(__file__).parent.parent / "_data" / "zenodo-releases.json"
-        public_path = Path(__file__).parent.parent / "assets" / "data" / "zenodo-releases.json"
-    # Write to file
-    with open(output_path, "w") as f:
-        json.dump(data, f, indent=2)
-        public_path.parent.mkdir(parents=True, exist_ok=True)
-        for path in (output_path, public_path):
-            with open(path, "w") as f:
-                json.dump(data, f, indent=2)
-            print(f"Updated {path}")
-    
+
+    # Write to data locations (Jekyll build + public asset)
+    output_path = Path(__file__).parent.parent / "_data" / "zenodo-releases.json"
+    public_path = Path(__file__).parent.parent / "assets" / "data" / "zenodo-releases.json"
+    public_path.parent.mkdir(parents=True, exist_ok=True)
+    for path in (output_path, public_path):
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+        print(f"Updated {path}")
+
     print(f"Found {len(data['releases'])} releases")
-    print(f"Updated {output_path}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- `scripts/fetch-zenodo-releases.py`'s `main()` had a malformed indentation (introduced in 670150e on 2026-01-23) causing `IndentationError` on every run. Since the workflow's final "Commit and push changes" step has no `if:` override, a failure in this step silently skips the commit — so `_data/citing-papers.json`, `_data/package-stats.json`, and `_data/zenodo-releases.json` haven't been updated in 25 straight weekly runs (confirmed via `gh run list --workflow=update-stats.yml`).
- `scripts/fetch-citing-papers.py` now preserves the last known-good `citing-papers.json` instead of overwriting it with an empty result when the ADS API call fails, so once the workflow starts committing again, a bad/expired `ADS_API_KEY` can't silently wipe the existing citation data.

## Separate issue (not fixed here, needs a repo admin)
The `ADS_API_KEY` secret is currently returning `401 Unauthorized` from the NASA ADS API. This needs a fresh token generated at https://ui.adsabs.harvard.edu/user/settings/token and updated in repo secrets — that's outside what this PR can fix.

## Test plan
- [x] `python3 -m py_compile scripts/fetch-zenodo-releases.py scripts/fetch-citing-papers.py`
- [x] Ran `fetch-zenodo-releases.py` locally — completes and writes valid JSON (19 releases found)
- [x] Ran `fetch-citing-papers.py` locally with `ADS_API_KEY` unset — confirmed existing `_data/citing-papers.json` is left untouched (verified via checksum) instead of being zeroed out
- [ ] Confirm the next scheduled/triggered `update-stats.yml` run completes and commits (once `ADS_API_KEY` is refreshed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)